### PR TITLE
feat : tag crud, 자동 완성 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 
+    implementation 'org.springframework.kafka:spring-kafka'
+
 }
 
 tasks.named('test') {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,12 +1,40 @@
-version: '1'
+version: '3.8'
 services:
-  recipe-app:
-    image: recipe-app:0.0.1
-    container_name: recipe
+  zookeeper:
+    image: wurstmeister/zookeeper
+    container_name: zookeeper
     ports:
-      - "8080:8080"
+      - "2181:2181"
     networks:
       - recipe
+
+  kafka:
+    image: wurstmeister/kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+#      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_NUM_PARTITIONS: 3
+    depends_on:
+      - zookeeper
+    networks:
+      - recipe
+
+#  recipe-app:
+#    image: recipe-app:0.0.1
+#    container_name: recipe
+#    ports:
+#      - "8080:8080"
+#    environment:
+#      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+#    depends_on:
+#      - kafka
+#    networks:
+#      - recipe
 
 networks:
   recipe:

--- a/src/main/java/focandlol/recipeproject/autocomplete/controller/AutoCompleteController.java
+++ b/src/main/java/focandlol/recipeproject/autocomplete/controller/AutoCompleteController.java
@@ -1,0 +1,21 @@
+package focandlol.recipeproject.autocomplete.controller;
+
+import focandlol.recipeproject.autocomplete.service.AutoCompleteService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AutoCompleteController {
+
+  private final AutoCompleteService autoCompleteService;
+
+  @GetMapping("/autocomplete")
+  public Map<String, Double> autoComplete(@RequestParam(required = false) String name) {
+    return autoCompleteService.getAuto(name);
+  }
+
+}

--- a/src/main/java/focandlol/recipeproject/autocomplete/service/AutoCompleteConsumer.java
+++ b/src/main/java/focandlol/recipeproject/autocomplete/service/AutoCompleteConsumer.java
@@ -1,0 +1,63 @@
+package focandlol.recipeproject.autocomplete.service;
+
+import static focandlol.recipeproject.type.RedisTag.AUTOCOMPLETE;
+import static focandlol.recipeproject.type.RedisTag.AUTOCOMPLETE_DELETE;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AutoCompleteConsumer {
+
+  private final RedisTemplate redisTemplate;
+
+  @KafkaListener(topics = "auto-complete-topic", groupId = "autocomplete-group")
+  public void addTag(List<String> tags, Acknowledgment ack) {
+    System.out.println("kafka");
+    for (String tag : tags) {
+      String n = tag.trim();
+      // 단어의 모든 접두어를 score 0으로 저장
+      for (int l = 0; l <= n.length(); l++) {
+        String prefix = n.substring(0, l);
+        redisTemplate.opsForZSet().incrementScore(AUTOCOMPLETE.toString(), prefix, 0);
+
+        //접두어 사용 빈도 저장
+        redisTemplate.opsForHash().increment(AUTOCOMPLETE_DELETE.toString(), prefix, 1);
+      }
+      // 원래 단어 저장
+      String perfect = n + "#";
+      redisTemplate.opsForZSet().incrementScore(AUTOCOMPLETE.toString(), perfect, 0);
+    }
+
+    ack.acknowledge();
+  }
+
+  @KafkaListener(topics = "auto-complete-delete-topic", groupId = "autocomplete-group")
+  public void deleteTag(List<String> tags, Acknowledgment ack) {
+    System.out.println("kafka-delete");
+
+    //원래 단어 삭제
+    Object[] array = tags.stream().map(a -> a + "#").toArray();
+    redisTemplate.opsForZSet().remove(AUTOCOMPLETE.toString(), array);
+    for (String tag : tags) {
+      String n = tag.trim();
+      for (int l = 1; l <= n.length(); l++) {
+        String prefix = n.substring(0, l);
+        //해당 접두어 score -1
+        Long score = redisTemplate.opsForHash().increment(AUTOCOMPLETE_DELETE.toString(), prefix, -1);
+
+        // 해당 접두어 score가 0이면 다른 곳에서 사용하지 않는 접두어이므로 삭제
+        if(score != null && score == 0){
+          redisTemplate.opsForHash().delete(AUTOCOMPLETE_DELETE.toString(), prefix);
+          redisTemplate.opsForZSet().remove(AUTOCOMPLETE.toString(), prefix);
+        }
+      }
+    }
+    ack.acknowledge();
+  }
+}

--- a/src/main/java/focandlol/recipeproject/autocomplete/service/AutoCompleteService.java
+++ b/src/main/java/focandlol/recipeproject/autocomplete/service/AutoCompleteService.java
@@ -25,28 +25,49 @@ public class AutoCompleteService {
   }
 
   /**
-   * 태그 자동완성용 캐시
-   * @param tags : 오리고기
-   *             오
-   *             오리
-   *             오리고
-   *             오리고기
-   *             오리고기# (원래 단어)
-   *             이런식으로 저장
+   * addAuto, delAuto kafka 처리 -> AutoCompleteConsumer
    */
-  public void addAuto(List<String> tags) {
-    for (String tag : tags) {
-      String n = tag.trim();
-      // 단어의 모든 접두어를 score 0으로 저장
-      for (int l = 0; l <= n.length(); l++) {
-        String prefix = n.substring(0, l);
-        redisTemplate.opsForZSet().incrementScore(AUTOCOMPLETE.toString(), prefix, 0);
-      }
-      // 원래 단어 저장
-      String perfect = n + "#";
-      redisTemplate.opsForZSet().incrementScore(AUTOCOMPLETE.toString(), perfect, 0);
-    }
-  }
+//  /**
+//   * 태그 자동완성용 캐시
+//   * @param tags : 오리고기
+//   *             오
+//   *             오리
+//   *             오리고
+//   *             오리고기
+//   *             오리고기# (원래 단어)
+//   *             이런식으로 저장
+//   */
+//  public void addAuto(List<String> tags) {
+//    for (String tag : tags) {
+//      String n = tag.trim();
+//      // 단어의 모든 접두어를 score 0으로 저장
+//      for (int l = 0; l <= n.length(); l++) {
+//        String prefix = n.substring(0, l);
+//        redisTemplate.opsForZSet().incrementScore(AUTOCOMPLETE.toString(), prefix, 0);
+//        redisTemplate.opsForHash().increment("del", prefix, 1);
+//      }
+//      // 원래 단어 저장
+//      String perfect = n + "#";
+//      redisTemplate.opsForZSet().incrementScore(AUTOCOMPLETE.toString(), perfect, 0);
+//    }
+//  }
+//
+//  public void delAuto(List<String> tags){
+//    Object[] array = tags.stream().map(a -> a + "#").toArray();
+//    redisTemplate.opsForZSet().remove(AUTOCOMPLETE.toString(), array);
+//    for (String tag : tags) {
+//      for (int l = 0; l <= tag.length(); l++) {
+//        String prefix = tag.substring(0, l);
+//
+//        Long score = redisTemplate.opsForHash().increment("del", prefix, -1);
+//
+//        if(score != null && score == 0){
+//          redisTemplate.opsForHash().delete("del", prefix);
+//          redisTemplate.opsForZSet().remove(AUTOCOMPLETE.toString(), prefix);
+//        }
+//      }
+//    }
+//  }
 
   /**
    * @param name : 오

--- a/src/main/java/focandlol/recipeproject/autocomplete/service/AutoCompleteService.java
+++ b/src/main/java/focandlol/recipeproject/autocomplete/service/AutoCompleteService.java
@@ -1,0 +1,100 @@
+package focandlol.recipeproject.autocomplete.service;
+
+import static focandlol.recipeproject.type.RedisTag.AUTOCOMPLETE;
+import static focandlol.recipeproject.type.RedisTag.TAG_RANKING;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AutoCompleteService {
+  private final RedisTemplate redisTemplate;
+
+  public Map<String,Double> getAuto(String name){
+    List<String> list = getList(name);
+    return sortList(list);
+  }
+
+  /**
+   * 태그 자동완성용 캐시
+   * @param tags : 오리고기
+   *             오
+   *             오리
+   *             오리고
+   *             오리고기
+   *             오리고기# (원래 단어)
+   *             이런식으로 저장
+   */
+  public void addAuto(List<String> tags) {
+    for (String tag : tags) {
+      String n = tag.trim();
+      // 단어의 모든 접두어를 score 0으로 저장
+      for (int l = 0; l <= n.length(); l++) {
+        String prefix = n.substring(0, l);
+        redisTemplate.opsForZSet().incrementScore(AUTOCOMPLETE.toString(), prefix, 0);
+      }
+      // 원래 단어 저장
+      String perfect = n + "#";
+      redisTemplate.opsForZSet().incrementScore(AUTOCOMPLETE.toString(), perfect, 0);
+    }
+  }
+
+  /**
+   * @param name : 오
+   * '오' 가 저장된 곳 id 조회
+   * 조회한 id + 500(태그 개수에 따라 바뀔 수 있음) 만큼 태그명 조회
+   * name으로 시작하고 #으로 끝나는 태그명(원래 단어 eg) 오리고기)만 리턴
+   */
+  private List<String> getList(String name){
+    Long auto = redisTemplate.opsForZSet().rank(AUTOCOMPLETE.toString(), name);
+
+    Set<String> set = redisTemplate.opsForZSet().range(AUTOCOMPLETE.toString(), auto, auto + 500);
+    if (auto == null || set.isEmpty()) return Collections.emptyList();
+
+    return set.stream()
+        .takeWhile(entry -> entry.startsWith(name))
+        .filter(entry -> entry.endsWith("#"))
+        .map(entry -> entry.substring(0, entry.length() - 1))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * 자동 완성 시 사용빈도가 많은 순으로 보이도록
+   * @param list : 원래 단어 들만 모인 리스트
+   *
+   */
+  private Map<String,Double> sortList(List<String> list){
+    if (list.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    // 해당 태그명에 맞는 score 조회
+    List<Double> scores = redisTemplate.opsForZSet().score(TAG_RANKING.toString(), list.toArray(new String[0]));
+
+    // 리스트에서 가져온 태그명 + score 매핑
+    Map<String, Double> scoreMap = new HashMap<>();
+    for (int i = 0; i < list.size(); i++) {
+      scoreMap.put(list.get(i), scores.get(i));
+    }
+
+    // 내림차순 정렬 + 상위 5개만 추출 (가장 많이 사용한 태그 5개)
+    return scoreMap.entrySet().stream()
+        .sorted((a, b) -> Double.compare(b.getValue(), a.getValue()))
+        .limit(5)
+        .collect(Collectors.toMap(
+            stringDoubleEntry -> stringDoubleEntry.getKey()
+            , stringDoubleEntry1 -> stringDoubleEntry1.getValue()
+            , (a, b) -> a, () -> new LinkedHashMap<>()
+        ));
+  }
+
+}

--- a/src/main/java/focandlol/recipeproject/global/TagScheduler.java
+++ b/src/main/java/focandlol/recipeproject/global/TagScheduler.java
@@ -58,7 +58,7 @@ public class TagScheduler {
   }
 
   private Set<ZSetOperations.TypedTuple<String>> getTagRanking() {
-    return redisTemplate.opsForZSet().rangeWithScores(TAG_RANKING, 0, -1);
+    return redisTemplate.opsForZSet().rangeWithScores(TAG_RANKING.toString(), 0, -1);
   }
 
 }

--- a/src/main/java/focandlol/recipeproject/global/exception/ErrorCode.java
+++ b/src/main/java/focandlol/recipeproject/global/exception/ErrorCode.java
@@ -25,7 +25,10 @@ public enum ErrorCode {
   /**
    * 시스템 에러
    */
-  INTERNAL_SERVER_ERROR("서버 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+  INTERNAL_SERVER_ERROR("서버 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+  INVALID_TAG("존재하지 않는 태그입니다.",BAD_REQUEST),
+  EXIST_TAG("이미 존재하는 태그입니다",BAD_REQUEST);
 
   private final String description;
   private final HttpStatus status;

--- a/src/main/java/focandlol/recipeproject/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/focandlol/recipeproject/global/exception/GlobalExceptionHandler.java
@@ -25,6 +25,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleException(Exception e) {
+    e.printStackTrace();
     return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR));
   }
 }

--- a/src/main/java/focandlol/recipeproject/tag/controller/TagController.java
+++ b/src/main/java/focandlol/recipeproject/tag/controller/TagController.java
@@ -1,10 +1,13 @@
 package focandlol.recipeproject.tag.controller;
 
 import focandlol.recipeproject.tag.dto.TagDto;
+import focandlol.recipeproject.tag.dto.UpdateTagDto;
 import focandlol.recipeproject.tag.service.TagService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,7 +18,17 @@ public class TagController {
   private final TagService tagService;
 
   @PostMapping("/tag")
-  public List<TagDto> addTag(@RequestBody List<String> names) {
-    return tagService.add(names);
+  public List<TagDto> addTag(@RequestBody List<String> tags) {
+    return tagService.add(tags);
+  }
+
+  @DeleteMapping("/tag")
+  public void deleteTag(@RequestBody List<String> tags) {
+    tagService.delete(tags);
+  }
+
+  @PutMapping("/tag")
+  public void updateTag(@RequestBody UpdateTagDto updateTagDto) {
+    tagService.update(updateTagDto.getTag(), updateTagDto.getChange());
   }
 }

--- a/src/main/java/focandlol/recipeproject/tag/dto/UpdateTagDto.java
+++ b/src/main/java/focandlol/recipeproject/tag/dto/UpdateTagDto.java
@@ -1,0 +1,15 @@
+package focandlol.recipeproject.tag.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateTagDto {
+
+  private String tag;
+
+  private String change;
+}

--- a/src/main/java/focandlol/recipeproject/tag/entity/TagEntity.java
+++ b/src/main/java/focandlol/recipeproject/tag/entity/TagEntity.java
@@ -13,10 +13,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/focandlol/recipeproject/tag/repository/TagRepository.java
+++ b/src/main/java/focandlol/recipeproject/tag/repository/TagRepository.java
@@ -2,8 +2,18 @@ package focandlol.recipeproject.tag.repository;
 
 import focandlol.recipeproject.tag.entity.TagEntity;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface TagRepository extends CrudRepository<TagEntity, Long> {
   List<TagEntity> findByNameIn(List<String> names);
+
+  Optional<TagEntity> findByName(String name);
+
+  @Modifying
+  @Query("delete from TagEntity t where t.name in :tags")
+  void deleteAllByNameIn(@Param("tags") List<String> tags);
 }

--- a/src/main/java/focandlol/recipeproject/tag/service/TagRedisService.java
+++ b/src/main/java/focandlol/recipeproject/tag/service/TagRedisService.java
@@ -1,0 +1,12 @@
+package focandlol.recipeproject.tag.service;
+
+import java.util.List;
+
+public interface TagRedisService {
+
+  void saveTagInRedis(List<String> tags, double score);
+
+  void deleteTagInRedis(List<String> tags);
+
+  void updateTagInRedis(String tag, String change);
+}

--- a/src/main/java/focandlol/recipeproject/tag/service/TagRedisServiceImpl.java
+++ b/src/main/java/focandlol/recipeproject/tag/service/TagRedisServiceImpl.java
@@ -1,0 +1,69 @@
+package focandlol.recipeproject.tag.service;
+
+import static focandlol.recipeproject.global.exception.ErrorCode.*;
+import static focandlol.recipeproject.type.RedisTag.AUTOCOMPLETE;
+import static focandlol.recipeproject.type.RedisTag.TAG_RANKING;
+
+import focandlol.recipeproject.autocomplete.service.AutoCompleteService;
+import focandlol.recipeproject.global.exception.CustomException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class TagRedisServiceImpl implements TagRedisService {
+
+  private final RedisTemplate redisTemplate;
+  private final AutoCompleteService autoCompleteService;
+
+  @Override
+  public void saveTagInRedis(List<String> tags, double score) {
+    saveTagRanking(tags, score);
+    //태그 자동완성 캐시
+    autoCompleteService.addAuto(tags);
+  }
+
+  /**
+   * @param tag 원래 태그명
+   * @param change 바꿀 태그명
+   */
+  public void updateTagInRedis(String tag, String change){
+
+    //이미 존재하는 태그로 수정 시 예외
+    Optional.ofNullable(redisTemplate.opsForZSet().score(TAG_RANKING.toString(), change))
+        .ifPresent(a -> {throw new CustomException(EXIST_TAG);});
+
+    //원래 태그명의 score 조회
+    Double score = redisTemplate.opsForZSet().score(TAG_RANKING.toString(), tag);
+
+    //원래 태그 삭제
+    deleteTagInRedis(Collections.singletonList(tag));
+
+    //원래 태그명의 score 더해서 새로운 태그 생성
+    saveTagInRedis(Collections.singletonList(change), score);
+  }
+
+  /**
+   * 태그 삭제
+   */
+  @Override
+  public void deleteTagInRedis(List<String> tags) {
+    redisTemplate.opsForZSet().remove(TAG_RANKING.toString(), tags.toArray());
+
+    //원래 단어만 삭제
+    Object[] array = tags.stream().map(a -> a + "#").toArray();
+    redisTemplate.opsForZSet().remove(AUTOCOMPLETE.toString(), array);
+  }
+
+  //태그 사용 횟수 캐시
+  private void saveTagRanking(List<String> tags, double score) {
+    for (String tag : tags) {
+      redisTemplate.opsForZSet().incrementScore(TAG_RANKING.toString(), tag, score);
+    }
+  }
+}

--- a/src/main/java/focandlol/recipeproject/tag/service/TagService.java
+++ b/src/main/java/focandlol/recipeproject/tag/service/TagService.java
@@ -6,4 +6,7 @@ import java.util.List;
 public interface TagService {
 
   List<TagDto> add(List<String> names);
+
+  void delete(List<String> tags);
+  void update(String tag, String change);
 }

--- a/src/main/java/focandlol/recipeproject/type/RedisTag.java
+++ b/src/main/java/focandlol/recipeproject/type/RedisTag.java
@@ -1,5 +1,6 @@
 package focandlol.recipeproject.type;
 
 public enum RedisTag {
-  TAG_RANKING
+  TAG_RANKING,
+  AUTOCOMPLETE
 }

--- a/src/main/java/focandlol/recipeproject/type/RedisTag.java
+++ b/src/main/java/focandlol/recipeproject/type/RedisTag.java
@@ -2,5 +2,6 @@ package focandlol.recipeproject.type;
 
 public enum RedisTag {
   TAG_RANKING,
-  AUTOCOMPLETE
+  AUTOCOMPLETE,
+  AUTOCOMPLETE_DELETE,
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**

**TO-BE**
태그 crud, 자동 완성 구현

나름대로 트래픽 상황, 태그 개수가 많아졌을 때를 고려해서 구현해보려고 노력했는데 괜찮을지 모르겠습니다.
AutoCompleteService addAuto()에서 특히 병목이 있을 것 같습니다.
아예 접두어 길이를 제한하던가 아니면 뭔가 batch 처리가 되면 해당 방법을 사용해야 할 것 같은데 혹시 좋은 방법 있으면 추천 부탁드립니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 