### PR TITLE
feat : 레시피 리스트 조회, 삭제, 수정 구현

### DIFF
--- a/src/main/java/focandlol/recipeproject/RecipeProjectApplication.java
+++ b/src/main/java/focandlol/recipeproject/RecipeProjectApplication.java
@@ -3,11 +3,13 @@ package focandlol.recipeproject;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 public class RecipeProjectApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/focandlol/recipeproject/airecipe/controller/AiRecipeController.java
+++ b/src/main/java/focandlol/recipeproject/airecipe/controller/AiRecipeController.java
@@ -1,5 +1,6 @@
 package focandlol.recipeproject.airecipe.controller;
 
+import focandlol.recipeproject.airecipe.dto.AiRecipeDetailsDto;
 import focandlol.recipeproject.airecipe.dto.AiRecipeDto;
 import focandlol.recipeproject.airecipe.dto.AiRecipeSearchDto;
 import focandlol.recipeproject.airecipe.dto.AiRecipeUpdateDto;
@@ -30,15 +31,15 @@ public class AiRecipeController {
   public String createRecipe(@AuthenticationPrincipal CustomOauth2User user,
       @RequestBody CreateAiRecipeDto createAiRecipeDto) {
     String recipe = aiRecipeService.generateRecipe(createAiRecipeDto, user);
-    aiRecipeService.saveRecipe(recipe, createAiRecipeDto,user);
+    aiRecipeService.saveRecipe(recipe, createAiRecipeDto, user);
 
     return recipe;
   }
 
   @GetMapping("/airecipe")
-  public List<AiRecipeDto> getRecipe(@AuthenticationPrincipal CustomOauth2User user,
+  public List<AiRecipeDto> getRecipes(@AuthenticationPrincipal CustomOauth2User user,
       @RequestBody AiRecipeSearchDto aiRecipeSearchDto) {
-    return aiRecipeService.getRecipe(user, aiRecipeSearchDto);
+    return aiRecipeService.getRecipes(user, aiRecipeSearchDto);
   }
 
   @PutMapping("/airecipe/{id}")
@@ -52,5 +53,12 @@ public class AiRecipeController {
   public void deleteRecipe(@AuthenticationPrincipal CustomOauth2User user
       , @PathVariable Long id) {
     aiRecipeService.deleteRecipe(user, id);
+  }
+
+  @GetMapping("/airecipe/{id}")
+  public AiRecipeDetailsDto getRecipe(@AuthenticationPrincipal CustomOauth2User user
+      , @PathVariable Long id
+  ){
+    return aiRecipeService.getRecipe(user, id);
   }
 }

--- a/src/main/java/focandlol/recipeproject/airecipe/dto/AiRecipeDetailsDto.java
+++ b/src/main/java/focandlol/recipeproject/airecipe/dto/AiRecipeDetailsDto.java
@@ -1,0 +1,45 @@
+package focandlol.recipeproject.airecipe.dto;
+
+import focandlol.recipeproject.airecipe.entity.AiRecipeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.NamedStoredProcedureQueries;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AiRecipeDetailsDto {
+
+  private Long id;
+
+  private String name;
+
+  private String content;
+
+  private Double temperature;
+
+  private String extraDetails;
+
+  private List<String> tags;
+
+  private LocalDateTime createdAt;
+
+  public static AiRecipeDetailsDto fromEntity(AiRecipeEntity aiRecipeEntity, List<String> tags){
+    return AiRecipeDetailsDto.builder()
+        .id(aiRecipeEntity.getId())
+        .name(aiRecipeEntity.getName())
+        .content(aiRecipeEntity.getContent())
+        .temperature(aiRecipeEntity.getTemperature())
+        .extraDetails(aiRecipeEntity.getExtraDetails())
+        .tags(tags)
+        .createdAt(aiRecipeEntity.getCreatedAt())
+        .build();
+  }
+
+}

--- a/src/main/java/focandlol/recipeproject/airecipe/dto/AiRecipeDto.java
+++ b/src/main/java/focandlol/recipeproject/airecipe/dto/AiRecipeDto.java
@@ -20,23 +20,14 @@ public class AiRecipeDto {
 
   private String name;
 
-  private String content;
-
-  private double temperature;
-
   private LocalDateTime createdAt;
-
-  private LocalDateTime updatedAt;
 
   public static List<AiRecipeDto> fromEntity(List<AiRecipeEntity> list) {
     return list.stream()
         .map(entity -> AiRecipeDto.builder()
             .id(entity.getId())
             .name(entity.getName())
-            .content(entity.getContent())
-            .temperature(entity.getTemperature())
             .createdAt(entity.getCreatedAt())
-            .updatedAt(entity.getUpdatedAt())
             .build()
         ).collect(Collectors.toList());
   }

--- a/src/main/java/focandlol/recipeproject/airecipe/entity/AiRecipeEntity.java
+++ b/src/main/java/focandlol/recipeproject/airecipe/entity/AiRecipeEntity.java
@@ -35,7 +35,7 @@ public class AiRecipeEntity extends BaseEntity {
   @Column(nullable = false, length = 20)
   private String name;
 
-  @Lob
+  @Column(columnDefinition = "TEXT")
   private String content;
 
   @Column(nullable = false)

--- a/src/main/java/focandlol/recipeproject/airecipe/service/AiRecipeService.java
+++ b/src/main/java/focandlol/recipeproject/airecipe/service/AiRecipeService.java
@@ -1,5 +1,6 @@
 package focandlol.recipeproject.airecipe.service;
 
+import focandlol.recipeproject.airecipe.dto.AiRecipeDetailsDto;
 import focandlol.recipeproject.airecipe.dto.AiRecipeDto;
 import focandlol.recipeproject.airecipe.dto.AiRecipeSearchDto;
 import focandlol.recipeproject.airecipe.dto.AiRecipeUpdateDto;
@@ -25,5 +26,7 @@ public interface AiRecipeService {
   void deleteRecipe(@AuthenticationPrincipal CustomOauth2User user, Long id);
 
   @Transactional
-  List<AiRecipeDto> getRecipe(CustomOauth2User user, AiRecipeSearchDto aiRecipeSearchDto);
+  List<AiRecipeDto> getRecipes(CustomOauth2User user, AiRecipeSearchDto aiRecipeSearchDto);
+
+  AiRecipeDetailsDto getRecipe(CustomOauth2User user, Long id);
 }

--- a/src/main/java/focandlol/recipeproject/recipe/controller/RecipeController.java
+++ b/src/main/java/focandlol/recipeproject/recipe/controller/RecipeController.java
@@ -2,11 +2,20 @@ package focandlol.recipeproject.recipe.controller;
 
 import focandlol.recipeproject.auth.dto.CustomOauth2User;
 import focandlol.recipeproject.recipe.dto.RecipeCreateDto;
+import focandlol.recipeproject.recipe.dto.RecipeDto;
+import focandlol.recipeproject.recipe.dto.RecipeSearchDto;
+import focandlol.recipeproject.recipe.dto.RecipeUpdateDto;
 import focandlol.recipeproject.recipe.service.RecipeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +29,27 @@ public class RecipeController {
   public RecipeCreateDto.Response addRecipe(@AuthenticationPrincipal CustomOauth2User user
       , @RequestBody @Valid RecipeCreateDto.Request request) {
     return recipeService.addRecipe(user, request);
+  }
+
+  @GetMapping("/recipe")
+  public Page<RecipeDto> getRecipes(@RequestBody(required = false) RecipeSearchDto search,
+      Pageable pageable) {
+    if (search == null) {
+      search = new RecipeSearchDto();
+    }
+    return recipeService.getRecipes(search, pageable);
+  }
+
+  @PutMapping("/recipe/{id}")
+  public RecipeUpdateDto.Response updateRecipe(@AuthenticationPrincipal CustomOauth2User user
+      , @PathVariable Long id
+      , @RequestBody @Valid RecipeUpdateDto.Request request) {
+
+    return recipeService.updateRecipe(user, request, id);
+  }
+
+  @DeleteMapping("/recipe/{id}")
+  public void deleteRecipe(@AuthenticationPrincipal CustomOauth2User user, @PathVariable Long id) {
+    recipeService.deleteRecipe(user, id);
   }
 }

--- a/src/main/java/focandlol/recipeproject/recipe/controller/RecipeController.java
+++ b/src/main/java/focandlol/recipeproject/recipe/controller/RecipeController.java
@@ -2,6 +2,7 @@ package focandlol.recipeproject.recipe.controller;
 
 import focandlol.recipeproject.auth.dto.CustomOauth2User;
 import focandlol.recipeproject.recipe.dto.RecipeCreateDto;
+import focandlol.recipeproject.recipe.dto.RecipeDetailsDto;
 import focandlol.recipeproject.recipe.dto.RecipeDto;
 import focandlol.recipeproject.recipe.dto.RecipeSearchDto;
 import focandlol.recipeproject.recipe.dto.RecipeUpdateDto;
@@ -51,5 +52,10 @@ public class RecipeController {
   @DeleteMapping("/recipe/{id}")
   public void deleteRecipe(@AuthenticationPrincipal CustomOauth2User user, @PathVariable Long id) {
     recipeService.deleteRecipe(user, id);
+  }
+
+  @GetMapping("/recipe/{id}")
+  public RecipeDetailsDto getRecipe(@PathVariable Long id){
+    return recipeService.getRecipe(id);
   }
 }

--- a/src/main/java/focandlol/recipeproject/recipe/dto/RecipeDetailsDto.java
+++ b/src/main/java/focandlol/recipeproject/recipe/dto/RecipeDetailsDto.java
@@ -1,0 +1,49 @@
+package focandlol.recipeproject.recipe.dto;
+
+import focandlol.recipeproject.recipe.entity.RecipeEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecipeDetailsDto {
+  private Long id;
+
+  private Long userId;
+
+  private String title;
+
+  private String name;
+
+  private String content;
+
+  private String bonus;
+
+  private Long count;
+
+  private List<String> tags;
+
+  private LocalDateTime createdAt;
+
+
+  public static RecipeDetailsDto fromEntity(RecipeEntity recipeEntity, List<String> tags) {
+    return RecipeDetailsDto.builder()
+        .id(recipeEntity.getId())
+        .userId(recipeEntity.getUser().getId())
+        .title(recipeEntity.getTitle())
+        .name(recipeEntity.getName())
+        .content(recipeEntity.getContent())
+        .bonus(recipeEntity.getBonus())
+        .count(recipeEntity.getCount())
+        .createdAt(recipeEntity.getCreatedAt())
+        .tags(tags)
+        .build();
+  }
+
+}

--- a/src/main/java/focandlol/recipeproject/recipe/dto/RecipeDto.java
+++ b/src/main/java/focandlol/recipeproject/recipe/dto/RecipeDto.java
@@ -2,6 +2,8 @@ package focandlol.recipeproject.recipe.dto;
 
 import focandlol.recipeproject.recipe.entity.RecipeEntity;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,16 +20,21 @@ public class RecipeDto {
 
   private String title;
 
+  private String name;
+
   private Long count;
 
   private LocalDateTime created;
 
-  public static Page<RecipeDto> fromEntity(Page<RecipeEntity> entities) {
-    return entities.map(entity -> RecipeDto.builder()
+  public static List<RecipeDto> fromEntity(Page<RecipeEntity> entities) {
+    return entities.getContent().stream()
+        .map(entity -> RecipeDto.builder()
             .id(entity.getId())
             .title(entity.getTitle())
+            .name(entity.getName())
             .count(entity.getCount())
             .created(entity.getCreatedAt())
-            .build());
+            .build())
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/focandlol/recipeproject/recipe/dto/RecipeDto.java
+++ b/src/main/java/focandlol/recipeproject/recipe/dto/RecipeDto.java
@@ -1,0 +1,33 @@
+package focandlol.recipeproject.recipe.dto;
+
+import focandlol.recipeproject.recipe.entity.RecipeEntity;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecipeDto {
+
+  private Long id;
+
+  private String title;
+
+  private Long count;
+
+  private LocalDateTime created;
+
+  public static Page<RecipeDto> fromEntity(Page<RecipeEntity> entities) {
+    return entities.map(entity -> RecipeDto.builder()
+            .id(entity.getId())
+            .title(entity.getTitle())
+            .count(entity.getCount())
+            .created(entity.getCreatedAt())
+            .build());
+  }
+}

--- a/src/main/java/focandlol/recipeproject/recipe/dto/RecipeSearchDto.java
+++ b/src/main/java/focandlol/recipeproject/recipe/dto/RecipeSearchDto.java
@@ -1,0 +1,22 @@
+package focandlol.recipeproject.recipe.dto;
+
+import focandlol.recipeproject.type.RecipeSearchType;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecipeSearchDto {
+
+  private List<String> tags;
+
+  private String keyword;
+
+  private RecipeSearchType sortBy;
+
+  private boolean upper;
+
+}

--- a/src/main/java/focandlol/recipeproject/recipe/dto/RecipeUpdateDto.java
+++ b/src/main/java/focandlol/recipeproject/recipe/dto/RecipeUpdateDto.java
@@ -1,0 +1,56 @@
+package focandlol.recipeproject.recipe.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RecipeUpdateDto {
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Request{
+    @NotEmpty
+    private List<@NotBlank String> tags;
+
+    @NotBlank
+    @Size(max = 20)
+    private String title;
+
+    @NotNull
+    @Size(max = 20)
+    private String name;
+
+    @Size(max = 200)
+    private String bonus;
+
+    @NotNull
+    private String content;
+  }
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Response{
+    private Long id;
+
+    private List<String> tags;
+
+    private String name;
+
+    private String title;
+
+    private String bonus;
+
+    private String content;
+  }
+
+}

--- a/src/main/java/focandlol/recipeproject/recipe/entity/RecipeEntity.java
+++ b/src/main/java/focandlol/recipeproject/recipe/entity/RecipeEntity.java
@@ -1,6 +1,7 @@
 package focandlol.recipeproject.recipe.entity;
 
 import focandlol.recipeproject.global.entity.BaseEntity;
+import focandlol.recipeproject.tag.entity.TagEntity;
 import focandlol.recipeproject.user.entity.UserEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/focandlol/recipeproject/recipe/entity/RecipeEntity.java
+++ b/src/main/java/focandlol/recipeproject/recipe/entity/RecipeEntity.java
@@ -46,4 +46,11 @@ public class RecipeEntity extends BaseEntity {
   private UserEntity user;
 
   private Long count;
+
+  public void updateRecipe(String title, String name, String content, String bonus){
+    this.title = title;
+    this.name = name;
+    this.content = content;
+    this.bonus = bonus;
+  }
 }

--- a/src/main/java/focandlol/recipeproject/recipe/entity/RecipeEntity.java
+++ b/src/main/java/focandlol/recipeproject/recipe/entity/RecipeEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
@@ -22,7 +23,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name = "recipe")
+@Table(name = "recipe",
+    indexes = {
+        @Index(name = "idx_recipe_count", columnList = "count DESC"), //좋아요 순
+        @Index(name = "idx_recipe_id", columnList = "recipe_id DESC") // 최신 순
+    })
 public class RecipeEntity extends BaseEntity {
 
   @Id
@@ -36,7 +41,7 @@ public class RecipeEntity extends BaseEntity {
   @Column(nullable = false, length = 20)
   private String name;
 
-  @Lob
+  @Column(columnDefinition = "TEXT")
   private String content;
 
   private String bonus;
@@ -47,7 +52,7 @@ public class RecipeEntity extends BaseEntity {
 
   private Long count;
 
-  public void updateRecipe(String title, String name, String content, String bonus){
+  public void updateRecipe(String title, String name, String content, String bonus) {
     this.title = title;
     this.name = name;
     this.content = content;

--- a/src/main/java/focandlol/recipeproject/recipe/entity/RecipeTagEntity.java
+++ b/src/main/java/focandlol/recipeproject/recipe/entity/RecipeTagEntity.java
@@ -1,6 +1,5 @@
 package focandlol.recipeproject.recipe.entity;
 
-import focandlol.recipeproject.airecipe.entity.AiRecipeEntity;
 import focandlol.recipeproject.tag.entity.TagEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -8,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -23,7 +23,11 @@ import org.hibernate.annotations.OnDeleteAction;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name = "recipe_tag")
+@Table(name = "recipe_tag",
+    indexes = {
+        @Index(name = "idx_recipe_tag_recipe_id", columnList = "recipe_id"), //조인 시
+        @Index(name = "idx_recipe_tag_tag_id", columnList = "tag_id") // 조인 시
+    })
 public class RecipeTagEntity {
 
   @Id

--- a/src/main/java/focandlol/recipeproject/recipe/repository/QueryRecipeRepository.java
+++ b/src/main/java/focandlol/recipeproject/recipe/repository/QueryRecipeRepository.java
@@ -1,0 +1,102 @@
+package focandlol.recipeproject.recipe.repository;
+
+import static focandlol.recipeproject.recipe.entity.QRecipeEntity.*;
+import static focandlol.recipeproject.recipe.entity.QRecipeTagEntity.*;
+import static focandlol.recipeproject.tag.entity.QTagEntity.tagEntity;
+import static focandlol.recipeproject.type.RecipeSearchType.*;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import focandlol.recipeproject.recipe.dto.RecipeSearchDto;
+import focandlol.recipeproject.recipe.entity.RecipeEntity;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class QueryRecipeRepository {
+
+  private final JPAQueryFactory query;
+
+  public QueryRecipeRepository(EntityManager em) {
+    this.query = new JPAQueryFactory(em);
+  }
+
+  public Page<RecipeEntity> findRecipes(
+      RecipeSearchDto searchDto, Pageable pageable){
+    List<RecipeEntity> content = query
+        .select(recipeEntity)
+        .from(recipeEntity)
+        .leftJoin(recipeTagEntity).on(recipeTagEntity.recipe.eq(recipeEntity))
+        .leftJoin(recipeTagEntity.tag, tagEntity)
+        .where(
+            containTag(searchDto.getTags()),
+            containKeyword(searchDto.getKeyword())
+        )
+        .groupBy(recipeEntity.id)
+        .having(havingCheck(searchDto.getTags()))
+        .orderBy(order(searchDto))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    long count = query
+        .select(recipeEntity.id)
+        .from(recipeEntity)
+        .leftJoin(recipeTagEntity).on(recipeTagEntity.recipe.eq(recipeEntity))
+        .leftJoin(recipeTagEntity.tag, tagEntity)
+        .where(
+            containTag(searchDto.getTags()),
+            containKeyword(searchDto.getKeyword())
+        )
+        .groupBy(recipeEntity.id)
+        .having(havingCheck(searchDto.getTags()))
+        .fetch()
+        .size();
+
+    return new PageImpl<>(content, pageable, count);
+  }
+
+  //태그 전부 포함하는지
+  private BooleanExpression havingCheck(List<String> tags) {
+    if(tags == null || tags.isEmpty()){
+      return null;
+    }
+    return recipeTagEntity.count().gt((long) tags.size());
+  }
+
+  //태그 포함하는지
+  private BooleanExpression containTag(List<String> tags){
+    if(tags == null || tags.isEmpty()) return null;
+    return tagEntity.name.in(tags);
+  }
+
+  //키워드 검색 조건
+  //제목, 레시피명, 내용
+  private BooleanExpression containKeyword(String keyword){
+    if(keyword == null || keyword.isEmpty()) return null;
+
+    BooleanExpression nameCondition = recipeEntity.name.containsIgnoreCase(keyword);
+    BooleanExpression titleCondition = recipeEntity.title.containsIgnoreCase(keyword);
+    BooleanExpression contentCondition = recipeEntity.content.containsIgnoreCase(keyword);
+
+    return nameCondition.or(titleCondition).or(contentCondition);
+  }
+
+  //정렬 조건
+  //좋아요 순, 최신 순
+  private OrderSpecifier<?> order(RecipeSearchDto request) {
+    Order order = request.isUpper() ? Order.ASC : Order.DESC;
+
+    if(request.getSortBy() != null && request.getSortBy() == LIKES){
+      return new OrderSpecifier<>(order, recipeEntity.count);
+    }else{
+      return new OrderSpecifier<>(order, recipeEntity.id);
+    }
+  }
+}

--- a/src/main/java/focandlol/recipeproject/recipe/repository/RecipeRepository.java
+++ b/src/main/java/focandlol/recipeproject/recipe/repository/RecipeRepository.java
@@ -1,8 +1,14 @@
 package focandlol.recipeproject.recipe.repository;
 
 import focandlol.recipeproject.recipe.entity.RecipeEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RecipeRepository extends JpaRepository<RecipeEntity, Long> {
+
+  @Query("select r from RecipeEntity r join fetch r.user where r.id = :recipeId")
+  Optional<RecipeEntity> findByIdFetch(@Param("recipeId") Long recipeId);
 
 }

--- a/src/main/java/focandlol/recipeproject/recipe/repository/RecipeTagRepository.java
+++ b/src/main/java/focandlol/recipeproject/recipe/repository/RecipeTagRepository.java
@@ -1,8 +1,22 @@
 package focandlol.recipeproject.recipe.repository;
 
 import focandlol.recipeproject.recipe.entity.RecipeTagEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RecipeTagRepository extends JpaRepository<RecipeTagEntity, Long> {
+  @Query("select t.name from RecipeTagEntity r "
+      + "join r.tag t "
+      + "where r.recipe.id = :recipeId")
+  List<String> findTagNamesByRecipeId(@Param("recipeId") Long recipeId);
 
+  @Modifying
+  @Query("delete from RecipeTagEntity r "
+      + "where r.recipe.id = :recipeId "
+      + "and r.tag.name in :tagNames")
+  void deleteRecipeTagIn(@Param("recipeId") Long recipeId,
+      @Param("tagNames") List<String> tagNames);
 }

--- a/src/main/java/focandlol/recipeproject/recipe/service/RecipeService.java
+++ b/src/main/java/focandlol/recipeproject/recipe/service/RecipeService.java
@@ -2,10 +2,22 @@ package focandlol.recipeproject.recipe.service;
 
 import focandlol.recipeproject.auth.dto.CustomOauth2User;
 import focandlol.recipeproject.recipe.dto.RecipeCreateDto;
+import focandlol.recipeproject.recipe.dto.RecipeDto;
+import focandlol.recipeproject.recipe.dto.RecipeSearchDto;
+import focandlol.recipeproject.recipe.dto.RecipeUpdateDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 public interface RecipeService {
 
   RecipeCreateDto.Response addRecipe(@AuthenticationPrincipal CustomOauth2User user
       , RecipeCreateDto.Request request);
+
+  Page<RecipeDto> getRecipes(RecipeSearchDto request, Pageable pageable);
+
+  RecipeUpdateDto.Response updateRecipe(CustomOauth2User user, RecipeUpdateDto.Request request,
+      Long id);
+
+  void deleteRecipe(CustomOauth2User user, Long id);
 }

--- a/src/main/java/focandlol/recipeproject/recipe/service/RecipeService.java
+++ b/src/main/java/focandlol/recipeproject/recipe/service/RecipeService.java
@@ -2,6 +2,7 @@ package focandlol.recipeproject.recipe.service;
 
 import focandlol.recipeproject.auth.dto.CustomOauth2User;
 import focandlol.recipeproject.recipe.dto.RecipeCreateDto;
+import focandlol.recipeproject.recipe.dto.RecipeDetailsDto;
 import focandlol.recipeproject.recipe.dto.RecipeDto;
 import focandlol.recipeproject.recipe.dto.RecipeSearchDto;
 import focandlol.recipeproject.recipe.dto.RecipeUpdateDto;
@@ -20,4 +21,6 @@ public interface RecipeService {
       Long id);
 
   void deleteRecipe(CustomOauth2User user, Long id);
+
+  RecipeDetailsDto getRecipe(Long id);
 }

--- a/src/main/java/focandlol/recipeproject/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/focandlol/recipeproject/recipe/service/RecipeServiceImpl.java
@@ -1,27 +1,39 @@
 package focandlol.recipeproject.recipe.service;
 
 import static focandlol.recipeproject.global.exception.ErrorCode.*;
-
 import focandlol.recipeproject.auth.dto.CustomOauth2User;
 import focandlol.recipeproject.global.exception.CustomException;
 import focandlol.recipeproject.recipe.dto.RecipeCreateDto;
+import focandlol.recipeproject.recipe.dto.RecipeDto;
+import focandlol.recipeproject.recipe.dto.RecipeSearchDto;
+import focandlol.recipeproject.recipe.dto.RecipeUpdateDto;
 import focandlol.recipeproject.recipe.entity.RecipeEntity;
+import focandlol.recipeproject.recipe.repository.QueryRecipeRepository;
 import focandlol.recipeproject.recipe.repository.RecipeRepository;
 import focandlol.recipeproject.tag.entity.TagEntity;
 import focandlol.recipeproject.tag.service.TagService;
 import focandlol.recipeproject.user.entity.UserEntity;
 import focandlol.recipeproject.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class RecipeServiceImpl implements RecipeService {
 
   private final UserRepository userRepository;
   private final RecipeRepository recipeRepository;
+  private final QueryRecipeRepository queryRecipeRepository;
   private final TagService tagService;
   private final RecipeTagService recipeTagService;
 
@@ -44,6 +56,101 @@ public class RecipeServiceImpl implements RecipeService {
     //recipe_tag 저장
     recipeTagService.save(save, tags);
 
-    return RecipeCreateDto.Response.fromEntity(save,tags);
+    return RecipeCreateDto.Response.fromEntity(save, tags);
+  }
+
+  @Override
+  public Page<RecipeDto> getRecipes(RecipeSearchDto request, Pageable pageable) {
+    return RecipeDto.fromEntity(queryRecipeRepository.findRecipes(request, pageable));
+  }
+
+  @Override
+  public RecipeUpdateDto.Response updateRecipe(CustomOauth2User user,
+      RecipeUpdateDto.Request request, Long id) {
+    RecipeEntity recipeEntity = recipeRepository.findById(id)
+        .orElseThrow(() -> new CustomException(RECIPE_NOT_FOUND));
+
+    validateUpdateRecipe(user, recipeEntity);
+
+    List<String> list = recipeTagService.findTagNamesByRecipeId(id);
+
+    Set<String> tags = new HashSet<>(request.getTags());
+
+    //삭제할 태그들
+    //원래 태그들 중에서 변경될 태그들에 포함되지 태그들 삭제
+    List<String> rmTag = findRemove(list, tags);
+
+    //추가될 태그들
+    //원래 저장되어 있던 태그들에 포함되지 않은 태그들 저장
+    List<String> save = findSave(list, tags);
+
+    //태그 저장
+    if (!save.isEmpty()) {
+      tagService.add(save);
+
+      //저장한 태그 조회
+      List<TagEntity> getTag = tagService.findByNameIn(save);
+
+      //recipe_tag 저장
+      recipeTagService.save(recipeEntity, getTag);
+    }
+
+    //아까 가져온 삭제할 태그들 삭제
+    if (!rmTag.isEmpty()) {
+      recipeTagService.deleteIn(id, rmTag);
+    }
+
+    //제목, 레시피명, 내용, 추가 설명 수정
+    recipeEntity.updateRecipe(request.getTitle(), request.getName(), request.getContent(),
+        request.getBonus());
+
+    return RecipeUpdateDto.Response.builder()
+        .id(recipeEntity.getId())
+        .tags(new ArrayList<>(tags))
+        .title(request.getTitle())
+        .name(request.getName())
+        .content(request.getContent())
+        .bonus(request.getBonus())
+        .build();
+  }
+
+  @Override
+  public void deleteRecipe(CustomOauth2User user, Long id){
+    validateDeleteRecipe(user, id);
+
+    recipeRepository.deleteById(id);
+  }
+
+  private void validateDeleteRecipe(CustomOauth2User user, Long id) {
+    UserEntity userEntity = userRepository.findById(user.getId())
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+    RecipeEntity recipeEntity = recipeRepository.findById(id)
+        .orElseThrow(() -> new CustomException(RECIPE_NOT_FOUND));
+
+    if (!recipeEntity.getUser().equals(userEntity)) {
+      throw new CustomException(ANOTHER_USER);
+    }
+  }
+
+  private void validateUpdateRecipe(CustomOauth2User user, RecipeEntity recipe) {
+    UserEntity userEntity = userRepository.findById(user.getId())
+        .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+    if (!recipe.getUser().equals(userEntity)) {
+      throw new CustomException(ANOTHER_USER);
+    }
+  }
+
+  private List<String> findSave(List<String> list, Set<String> tags) {
+    return tags.stream()
+        .filter(tag -> !list.contains(tag))
+        .collect(Collectors.toList());
+  }
+
+  private List<String> findRemove(List<String> list, Set<String> tags) {
+    return list.stream()
+        .filter(tag -> !tags.contains(tag))
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/focandlol/recipeproject/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/focandlol/recipeproject/recipe/service/RecipeServiceImpl.java
@@ -4,6 +4,7 @@ import static focandlol.recipeproject.global.exception.ErrorCode.*;
 import focandlol.recipeproject.auth.dto.CustomOauth2User;
 import focandlol.recipeproject.global.exception.CustomException;
 import focandlol.recipeproject.recipe.dto.RecipeCreateDto;
+import focandlol.recipeproject.recipe.dto.RecipeDetailsDto;
 import focandlol.recipeproject.recipe.dto.RecipeDto;
 import focandlol.recipeproject.recipe.dto.RecipeSearchDto;
 import focandlol.recipeproject.recipe.dto.RecipeUpdateDto;
@@ -124,6 +125,15 @@ public class RecipeServiceImpl implements RecipeService {
     validateDeleteRecipe(user, id);
 
     recipeRepository.deleteById(id);
+  }
+
+  public RecipeDetailsDto getRecipe(Long id){
+    RecipeEntity recipeEntity = recipeRepository.findByIdFetch(id)
+        .orElseThrow(() -> new CustomException(RECIPE_NOT_FOUND));
+
+    List<String> tags = recipeTagService.findTagNamesByRecipeId(id);
+
+    return RecipeDetailsDto.fromEntity(recipeEntity, tags);
   }
 
   private void validateDeleteRecipe(CustomOauth2User user, Long id) {

--- a/src/main/java/focandlol/recipeproject/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/focandlol/recipeproject/recipe/service/RecipeServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
@@ -61,7 +62,11 @@ public class RecipeServiceImpl implements RecipeService {
 
   @Override
   public Page<RecipeDto> getRecipes(RecipeSearchDto request, Pageable pageable) {
-    return RecipeDto.fromEntity(queryRecipeRepository.findRecipes(request, pageable));
+    Page<RecipeEntity> recipes = queryRecipeRepository.findRecipes(request, pageable);
+
+    List<RecipeDto> recipeDtos = RecipeDto.fromEntity(recipes);
+
+    return new PageImpl<>(recipeDtos, pageable, recipes.getTotalElements());
   }
 
   @Override

--- a/src/main/java/focandlol/recipeproject/recipe/service/RecipeTagService.java
+++ b/src/main/java/focandlol/recipeproject/recipe/service/RecipeTagService.java
@@ -7,4 +7,8 @@ import java.util.List;
 public interface RecipeTagService {
 
   void save(RecipeEntity recipe, List<TagEntity> tags);
+
+  List<String> findTagNamesByRecipeId(Long id);
+
+  void deleteIn(Long id, List<String> tags);
 }

--- a/src/main/java/focandlol/recipeproject/recipe/service/RecipeTagServiceImpl.java
+++ b/src/main/java/focandlol/recipeproject/recipe/service/RecipeTagServiceImpl.java
@@ -25,4 +25,14 @@ public class RecipeTagServiceImpl implements RecipeTagService {
         .collect(Collectors.toList()));
   }
 
+  @Override
+  public void deleteIn(Long id, List<String> tags){
+    recipeTagRepository.deleteRecipeTagIn(id, tags);
+  }
+
+  @Override
+  public List<String> findTagNamesByRecipeId(Long id){
+    return recipeTagRepository.findTagNamesByRecipeId(id);
+  }
+
 }

--- a/src/main/java/focandlol/recipeproject/type/RecipeSearchType.java
+++ b/src/main/java/focandlol/recipeproject/type/RecipeSearchType.java
@@ -1,0 +1,7 @@
+package focandlol.recipeproject.type;
+
+public enum RecipeSearchType {
+
+  LIKES, LATEST
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
레시피 리스트 조회, 수정, 삭제 구현

레시피 조회 쿼리가 groupby + 페이징 을 사용해서 count 쿼리 성능이 괜찮을 지 모르겠습니다.
이걸 querydsl로 해결할 수 있는지, 혹은 다른 방법이 있는지 궁금합니다. 
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 